### PR TITLE
Problem: service file bad location on 64bit rpm systems

### DIFF
--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -50,7 +50,7 @@ src_malamute_LDADD = ${program_libs}
 src_malamute_SOURCES = src/malamute.c
 src_malamute_configdir = $(sysconfdir)/malamute
 src_malamute_config_DATA = src/malamute.cfg
-src_malamute_servicedir = @libdir@/systemd/system
+src_malamute_servicedir = @prefix@/lib/systemd/system
 src_malamute_service_DATA = src/malamute.service
 
 bin_PROGRAMS += src/mshell


### PR DESCRIPTION
Solution: use @prefix@/lib instead of libdir, which expands to
/usr/lib64 in rpm distros, where systemd does expects /usr/lib