### PR TITLE
Problem: Can't run make check

### DIFF
--- a/src/mlm_client.c
+++ b/src/mlm_client.c
@@ -418,10 +418,10 @@ mlm_client_test (bool verbose)
     writer = mlm_client_new ("ipc://@/malamute", 1000, "writer/secret");
     assert (writer);
 
-    mlm_client_t *reader1 = mlm_client_new ("ipc://@/malamute", 1000, "reader/secret");
+    mlm_client_t *reader1 = mlm_client_new ("ipc://@/malamute", 1000, "reader1/secret");
     assert (reader1);
 
-    mlm_client_t *reader2 = mlm_client_new ("ipc://@/malamute", 1000, "reader/secret");
+    mlm_client_t *reader2 = mlm_client_new ("ipc://@/malamute", 1000, "reader2/secret");
     assert (reader2);
 
     mlm_client_set_producer (writer, "weather");

--- a/src/passwords.cfg
+++ b/src/passwords.cfg
@@ -1,5 +1,7 @@
 #   Test password used by mlm_client
 #   username is mailbox address
 reader=secret
+reader1=secret
+reader2=secret
 writer=secret
 mshell=mshell


### PR DESCRIPTION
Running make check on the latest master gets stuck. Culprit from the
bisect point of view seems to be commit c139362. In the fact, in the
light of this commit test seems to be4 stuck kinda correctly as two
clients shouldn't have the same name.

Solution: Use two different client names in the test