### PR TITLE
Problem: self test does not complete (duplicate addresses)

### DIFF
--- a/src/mlm_client.c
+++ b/src/mlm_client.c
@@ -421,7 +421,7 @@ mlm_client_test (bool verbose)
     mlm_client_t *reader1 = mlm_client_new ("ipc://@/malamute", 1000, "reader/secret");
     assert (reader1);
 
-    mlm_client_t *reader2 = mlm_client_new ("ipc://@/malamute", 1000, "reader/secret");
+    mlm_client_t *reader2 = mlm_client_new ("ipc://@/malamute", 1000, "second/secret");
     assert (reader2);
 
     mlm_client_set_producer (writer, "weather");

--- a/src/passwords.cfg
+++ b/src/passwords.cfg
@@ -1,5 +1,6 @@
 #   Test password used by mlm_client
 #   username is mailbox address
 reader=secret
+second=secret
 writer=secret
 mshell=mshell


### PR DESCRIPTION
The mlm_client test case was using two clients with the same address
(reader). The server does not allow this any longer. So the test case
failed.

Solution: use a different address for each unique client.

Fixes #55